### PR TITLE
[C3PO-13] Add JWT implementation on Code API

### DIFF
--- a/src/api/auth/jwt/tokenizer_test.go
+++ b/src/api/auth/jwt/tokenizer_test.go
@@ -10,6 +10,10 @@ import (
 
 var defaultSha = "52bfd2de0a2e69dff4517518590ac32a46bd76606ec22a258f99584a6e70aca2"
 
+var DefaultTokenHandler = TokenHandler{
+	Secret: FetchJwtSecret(),
+}
+
 func TestSecret_DefaultValue(t *testing.T) {
 	err := os.Unsetenv("JWT_SECRET")
 

--- a/src/api/controller/code/auth_middleware.go
+++ b/src/api/controller/code/auth_middleware.go
@@ -1,0 +1,48 @@
+package code
+
+import (
+	"fmt"
+	"github.com/arpb2/C-3PO/src/api/engine"
+	"github.com/gin-gonic/gin"
+	"net/http"
+	"strconv"
+)
+
+func HandleAuthentication(ctx *gin.Context) {
+	authToken := ctx.GetHeader("Authentication")
+
+	if authToken == "" {
+		ctx.JSON(http.StatusUnauthorized, gin.H{
+			"error": "no 'Authentication' header provided",
+		})
+		ctx.Abort()
+		return
+	}
+
+	token, err := engine.DefaultTokenHandler.Retrieve(authToken)
+
+	if err != nil {
+		ctx.JSON(err.Status, gin.H{
+			"error": err.Error.Error(),
+		})
+		ctx.Abort()
+		return
+	}
+
+	if strconv.FormatUint(uint64(token.UserId), 10) != ctx.Param("user_id") {
+		go func(userId string, requestUrl string) {
+			if userId == "" {
+				fmt.Printf("Got an unauthorized because of no existing parameter 'user_id' in request " +
+					"'%s'. Maybe you are malforming the Controller?", requestUrl)
+			}
+		}(ctx.Param("user_id"), ctx.Request.URL.String())
+
+		ctx.JSON(http.StatusUnauthorized, gin.H{
+			"error": "unauthorized",
+		})
+		ctx.Abort()
+		return
+	}
+
+	ctx.Next()
+}

--- a/src/api/controller/code/auth_middleware_test.go
+++ b/src/api/controller/code/auth_middleware_test.go
@@ -1,0 +1,106 @@
+package code
+
+import (
+	"github.com/arpb2/C-3PO/src/api/controller"
+	"github.com/arpb2/C-3PO/src/api/engine"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func performRequest(r http.Handler, method, path, body string, headers map[string][]string) *httptest.ResponseRecorder {
+	req, _ := http.NewRequest(method, path, strings.NewReader(body))
+	req.Header = headers
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestHandlingOfAuthentication_NoHeader(t *testing.T) {
+	e := engine.CreateBasicServerEngine()
+	e.Register(controller.Controller{
+		Method:        "GET",
+		Path:          "/test",
+		Middleware:    []gin.HandlerFunc{
+			HandleAuthentication,
+		},
+		Body:          func(ctx *gin.Context) {
+			panic("Shouldn't reach here!")
+		},
+	})
+
+	recorder := performRequest(e, "GET", "/test", "", map[string][]string{})
+
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+	assert.Equal(t, "{\"error\":\"no 'Authentication' header provided\"}\n", recorder.Body.String())
+}
+
+func TestHandlingOfAuthentication_BadHeader(t *testing.T) {
+	e := engine.CreateBasicServerEngine()
+	e.Register(controller.Controller{
+		Method:        "GET",
+		Path:          "/test",
+		Middleware:    []gin.HandlerFunc{
+			HandleAuthentication,
+		},
+		Body:          func(ctx *gin.Context) {
+			panic("Shouldn't reach here!")
+		},
+	})
+
+	headers := map[string][]string{}
+	headers["Authentication"] = []string{"bad token"}
+	recorder := performRequest(e, "GET", "/test", "", headers)
+
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.Equal(t, "{\"error\":\"malformed token\"}\n", recorder.Body.String())
+}
+
+func TestHandlingOfAuthentication_UnauthorizedUser(t *testing.T) {
+	e := engine.CreateBasicServerEngine()
+	e.Register(controller.Controller{
+		Method:        "GET",
+		Path:          "/test/:user_id",
+		Middleware:    []gin.HandlerFunc{
+			HandleAuthentication,
+		},
+		Body:          func(ctx *gin.Context) {
+			panic("Shouldn't reach here!")
+		},
+	})
+
+	headers := map[string][]string{}
+	// Token for user 1000
+	headers["Authentication"] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDB9.GVS-KC5nOCHybzzFIIH864u4KcGu-ZSd-96krqTUGWo"}
+	recorder := performRequest(e, "GET", "/test/1", "", headers)
+
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+	assert.Equal(t, "{\"error\":\"unauthorized\"}\n", recorder.Body.String())
+}
+
+func TestHandlingOfAuthentication_Authorized(t *testing.T) {
+	e := engine.CreateBasicServerEngine()
+	e.Register(controller.Controller{
+		Method:        "GET",
+		Path:          "/test/:user_id",
+		Middleware:    []gin.HandlerFunc{
+			HandleAuthentication,
+		},
+		Body:          func(ctx *gin.Context) {
+			ctx.String(http.StatusOK, "Returned success")
+		},
+	})
+
+	headers := map[string][]string{}
+	// Token for user 1000
+	headers["Authentication"] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDB9.GVS-KC5nOCHybzzFIIH864u4KcGu-ZSd-96krqTUGWo"}
+	recorder := performRequest(e, "GET", "/test/1000", "", headers)
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Equal(t, "Returned success", recorder.Body.String())
+}
+

--- a/src/api/controller/code/code_controller.go
+++ b/src/api/controller/code/code_controller.go
@@ -9,18 +9,27 @@ import (
 var GetController = controller.Controller{
 	Method: "GET",
 	Path:   "/users/:user_id/codes/:code_id",
+	Middleware: []gin.HandlerFunc{
+		HandleAuthentication,
+	},
 	Body:   codeGet,
 }
 
 var PostController = controller.Controller{
 	Method: "POST",
 	Path:   "/users/:user_id/codes",
+	Middleware: []gin.HandlerFunc{
+		HandleAuthentication,
+	},
 	Body:   codePost,
 }
 
 var PutController = controller.Controller{
 	Method: "PUT",
 	Path:   "/users/:user_id/codes/:code_id",
+	Middleware: []gin.HandlerFunc{
+		HandleAuthentication,
+	},
 	Body:   codePut,
 }
 

--- a/src/api/controller/controller.go
+++ b/src/api/controller/controller.go
@@ -7,5 +7,7 @@ type Controller struct {
 
 	Path string
 
+	Middleware []gin.HandlerFunc
+
 	Body gin.HandlerFunc
 }

--- a/src/api/engine/engine.go
+++ b/src/api/engine/engine.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"github.com/arpb2/C-3PO/src/api/auth/jwt"
 	"github.com/arpb2/C-3PO/src/api/controller"
 	"github.com/gin-gonic/gin"
 	"net/http"
@@ -22,6 +23,10 @@ func CreateBasicServerEngine() ServerEngine {
 	}
 }
 
+var DefaultTokenHandler = jwt.TokenHandler{
+	Secret: jwt.FetchJwtSecret(),
+}
+
 type defaultServerEngine struct {
 	engine *gin.Engine
 	port   string
@@ -36,10 +41,17 @@ func (server defaultServerEngine) Run() error {
 }
 
 func (server defaultServerEngine) Register(controller controller.Controller) {
+	var handlers []gin.HandlerFunc
+	handlers = append(handlers, gin.Logger(), gin.Recovery())
+	if controller.Middleware != nil {
+		handlers = append(handlers, controller.Middleware...)
+	}
+	handlers = append(handlers, controller.Body)
+
 	server.engine.Handle(
 		controller.Method,
 		controller.Path,
-		controller.Body,
+		handlers...,
 	)
 }
 


### PR DESCRIPTION
- Add to controllers the possibility of adding own middlewares
- Add default middlewares to engine (log / recover)
- Create middleware of JWT implementation for code
- Add logic to middleware that validates only on user_id parameter (on a future
    step we will probably want to add more logic, such as allowing
    professors to read students code)

We didn't use a global middleware for authenticating because not all
endpoints will contain authentication AND not necessarily all
authenticated endpoints will be the same (eg. Code will authenticate
    against the student + professor, while users API will probably only
    authenticate against the own user)