### PR TITLE
[C3PO-30] Single entry-point tree graph

### DIFF
--- a/src/api/controller/code/code_binder.go
+++ b/src/api/controller/code/code_binder.go
@@ -1,0 +1,25 @@
+package code
+
+import (
+	"github.com/arpb2/C-3PO/src/api/engine"
+	"github.com/arpb2/C-3PO/src/api/http_wrapper"
+	"github.com/arpb2/C-3PO/src/api/service"
+)
+
+type binder struct {
+	AuthMiddleware http_wrapper.Handler
+	CodeService service.CodeService
+}
+
+func (b binder) BindControllers(controllerRegistrable engine.ControllerRegistrable) {
+	controllerRegistrable.Register(CreateGetController(b.AuthMiddleware, b.CodeService))
+	controllerRegistrable.Register(CreatePostController(b.AuthMiddleware, b.CodeService))
+	controllerRegistrable.Register(CreatePutController(b.AuthMiddleware, b.CodeService))
+}
+
+func CreateBinder(authMiddleware http_wrapper.Handler, codeService service.CodeService) engine.ControllerBinder {
+	return &binder{
+		AuthMiddleware: authMiddleware,
+		CodeService:    codeService,
+	}
+}

--- a/src/api/controller/code/code_binder_test.go
+++ b/src/api/controller/code/code_binder_test.go
@@ -1,0 +1,50 @@
+package code_test
+
+import (
+	"github.com/arpb2/C-3PO/src/api/controller"
+	"github.com/arpb2/C-3PO/src/api/controller/code"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type MockControllerRegistrable struct{
+	RegisteredControllers []controller.Controller
+}
+
+func (m *MockControllerRegistrable) Register(controller controller.Controller) {
+	m.RegisteredControllers = append(m.RegisteredControllers, controller)
+}
+
+func bindControllers() *MockControllerRegistrable {
+	binder := code.CreateBinder(nil, nil)
+	registrable := &MockControllerRegistrable{}
+
+	binder.BindControllers(registrable)
+
+	return registrable
+}
+
+func lookupController(path string) controller.Controller {
+	registrable := bindControllers()
+	var expectedController controller.Controller
+
+	for _, registeredController := range registrable.RegisteredControllers {
+		if registeredController.Path == path {
+			expectedController = registeredController
+		}
+	}
+
+	return expectedController
+}
+
+func TestCreateBinder_RegistersRoutes(t *testing.T) {
+	assert.NotNil(t, lookupController("GET"))
+	assert.NotNil(t, lookupController("POST"))
+	assert.NotNil(t, lookupController("PUT"))
+}
+
+func TestCreateBinder_RegistersOnlyRoutes(t *testing.T) {
+	registrable := bindControllers()
+
+	assert.Equal(t, 3, len(registrable.RegisteredControllers))
+}

--- a/src/api/controller/code/code_controller.go
+++ b/src/api/controller/code/code_controller.go
@@ -1,25 +1,11 @@
 package code
 
 import (
-	"github.com/arpb2/C-3PO/src/api/auth/jwt"
 	"github.com/arpb2/C-3PO/src/api/controller"
-	"github.com/arpb2/C-3PO/src/api/engine"
 	"github.com/arpb2/C-3PO/src/api/http_wrapper"
-	"github.com/arpb2/C-3PO/src/api/middleware/auth/teacher_auth"
-	"github.com/arpb2/C-3PO/src/api/service/code_service"
-	"github.com/arpb2/C-3PO/src/api/service/teacher_service"
 	"net/http"
 	"strconv"
 )
-
-func Binder(handler engine.ControllerRegistrable) {
-	authMiddleware := teacher_auth.CreateMiddleware(jwt.CreateTokenHandler(), teacher_service.GetService())
-	codeService := code_service.GetService()
-
-	handler.Register(CreateGetController(authMiddleware, codeService))
-	handler.Register(CreatePostController(authMiddleware, codeService))
-	handler.Register(CreatePutController(authMiddleware, codeService))
-}
 
 func FetchUserId(ctx *http_wrapper.Context) (uint, bool) {
 	userId := ctx.GetParameter("user_id")

--- a/src/api/controller/code/code_get_controller_test.go
+++ b/src/api/controller/code/code_get_controller_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/arpb2/C-3PO/src/api/middleware/auth/teacher_auth"
 	"github.com/arpb2/C-3PO/src/api/service/code_service"
 	"github.com/arpb2/C-3PO/src/api/service/teacher_service"
+	"github.com/arpb2/C-3PO/src/api/service/user_service"
 	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
@@ -21,9 +22,9 @@ func createGetController() controller.Controller {
 	return code.CreateGetController(
 		teacher_auth.CreateMiddleware(
 			jwt.CreateTokenHandler(),
-			teacher_service.GetService(),
+			teacher_service.CreateService(user_service.CreateService()),
 		),
-		code_service.GetService(),
+		code_service.CreateService(),
 	)
 }
 

--- a/src/api/controller/code/code_post_controller_test.go
+++ b/src/api/controller/code/code_post_controller_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/arpb2/C-3PO/src/api/middleware/auth/teacher_auth"
 	"github.com/arpb2/C-3PO/src/api/service/code_service"
 	"github.com/arpb2/C-3PO/src/api/service/teacher_service"
+	"github.com/arpb2/C-3PO/src/api/service/user_service"
 	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
@@ -21,9 +22,9 @@ func createPostController() controller.Controller {
 	return code.CreatePostController(
 		teacher_auth.CreateMiddleware(
 			jwt.CreateTokenHandler(),
-			teacher_service.GetService(),
+			teacher_service.CreateService(user_service.CreateService()),
 		),
-		code_service.GetService(),
+		code_service.CreateService(),
 	)
 }
 

--- a/src/api/controller/code/code_put_controller_test.go
+++ b/src/api/controller/code/code_put_controller_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/arpb2/C-3PO/src/api/middleware/auth/teacher_auth"
 	"github.com/arpb2/C-3PO/src/api/service/code_service"
 	"github.com/arpb2/C-3PO/src/api/service/teacher_service"
+	"github.com/arpb2/C-3PO/src/api/service/user_service"
 	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
@@ -21,9 +22,9 @@ func createPutController() controller.Controller {
 	return code.CreatePutController(
 		teacher_auth.CreateMiddleware(
 			jwt.CreateTokenHandler(),
-			teacher_service.GetService(),
+			teacher_service.CreateService(user_service.CreateService()),
 		),
-		code_service.GetService(),
+		code_service.CreateService(),
 	)
 }
 

--- a/src/api/controller/health/health_binder.go
+++ b/src/api/controller/health/health_binder.go
@@ -1,0 +1,13 @@
+package health
+
+import "github.com/arpb2/C-3PO/src/api/engine"
+
+type binder struct{}
+
+func (b binder) BindControllers(controllerRegistrable engine.ControllerRegistrable) {
+	controllerRegistrable.Register(GetController)
+}
+
+func CreateBinder() engine.ControllerBinder {
+	return &binder{}
+}

--- a/src/api/controller/health/health_binder.go
+++ b/src/api/controller/health/health_binder.go
@@ -5,7 +5,7 @@ import "github.com/arpb2/C-3PO/src/api/engine"
 type binder struct{}
 
 func (b binder) BindControllers(controllerRegistrable engine.ControllerRegistrable) {
-	controllerRegistrable.Register(GetController)
+	controllerRegistrable.Register(CreateGetController())
 }
 
 func CreateBinder() engine.ControllerBinder {

--- a/src/api/controller/health/health_binder_test.go
+++ b/src/api/controller/health/health_binder_test.go
@@ -1,0 +1,48 @@
+package health_test
+
+import (
+	"github.com/arpb2/C-3PO/src/api/controller"
+	"github.com/arpb2/C-3PO/src/api/controller/health"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type MockControllerRegistrable struct{
+	RegisteredControllers []controller.Controller
+}
+
+func (m *MockControllerRegistrable) Register(controller controller.Controller) {
+	m.RegisteredControllers = append(m.RegisteredControllers, controller)
+}
+
+func bindControllers() *MockControllerRegistrable {
+	binder := health.CreateBinder()
+	registrable := &MockControllerRegistrable{}
+
+	binder.BindControllers(registrable)
+
+	return registrable
+}
+
+func lookupController(path string) controller.Controller {
+	registrable := bindControllers()
+	var expectedController controller.Controller
+
+	for _, registeredController := range registrable.RegisteredControllers {
+		if registeredController.Path == path {
+			expectedController = registeredController
+		}
+	}
+
+	return expectedController
+}
+
+func TestCreateBinder_RegistersRoutes(t *testing.T) {
+	assert.NotNil(t, lookupController("GET"))
+}
+
+func TestCreateBinder_RegistersOnlyRoutes(t *testing.T) {
+	registrable := bindControllers()
+
+	assert.Equal(t, 1, len(registrable.RegisteredControllers))
+}

--- a/src/api/controller/health/health_controller.go
+++ b/src/api/controller/health/health_controller.go
@@ -2,14 +2,9 @@ package health
 
 import (
 	"github.com/arpb2/C-3PO/src/api/controller"
-	"github.com/arpb2/C-3PO/src/api/engine"
 	"github.com/arpb2/C-3PO/src/api/http_wrapper"
 	"net/http"
 )
-
-func Binder(handler engine.ControllerRegistrable) {
-	handler.Register(GetController)
-}
 
 var GetController = controller.Controller{
 	Method: "GET",

--- a/src/api/controller/health/health_controller.go
+++ b/src/api/controller/health/health_controller.go
@@ -6,10 +6,12 @@ import (
 	"net/http"
 )
 
-var GetController = controller.Controller{
-	Method: "GET",
-	Path:   "/ping",
-	Body:   healthGet,
+func CreateGetController() controller.Controller {
+	return controller.Controller{
+		Method: "GET",
+		Path:   "/ping",
+		Body:   healthGet,
+	}
 }
 
 func healthGet(ctx *http_wrapper.Context) {

--- a/src/api/controller/health/health_controller_test.go
+++ b/src/api/controller/health/health_controller_test.go
@@ -8,17 +8,17 @@ import (
 )
 
 func TestHealthControllerMethodIsGET(t *testing.T) {
-	assert.Equal(t, "GET", health.GetController.Method)
+	assert.Equal(t, "GET", health.CreateGetController().Method)
 }
 
 func TestHealthControllerPathIsPing(t *testing.T) {
-	assert.Equal(t, "/ping", health.GetController.Path)
+	assert.Equal(t, "/ping", health.CreateGetController().Path)
 }
 
 func TestHealthControllerBodyReturnsWith200IfItsOk(t *testing.T) {
 	c, w := gin_wrapper.CreateTestContext()
 
-	health.GetController.Body(c)
+	health.CreateGetController().Body(c)
 
 	assert.Equal(t, 200, w.Code)
 }

--- a/src/api/controller/user/user_binder.go
+++ b/src/api/controller/user/user_binder.go
@@ -1,0 +1,27 @@
+package user
+
+import (
+	"github.com/arpb2/C-3PO/src/api/engine"
+	"github.com/arpb2/C-3PO/src/api/http_wrapper"
+	"github.com/arpb2/C-3PO/src/api/service"
+)
+
+type binder struct {
+	AuthMiddleware http_wrapper.Handler
+	UserService service.UserService
+}
+
+func (b binder) BindControllers(controllerRegistrable engine.ControllerRegistrable) {
+	controllerRegistrable.Register(CreatePostController(b.UserService))
+
+	controllerRegistrable.Register(CreateGetController(b.AuthMiddleware, b.UserService))
+	controllerRegistrable.Register(CreatePutController(b.AuthMiddleware, b.UserService))
+	controllerRegistrable.Register(CreateDeleteController(b.AuthMiddleware, b.UserService))
+}
+
+func CreateBinder(authMiddleware http_wrapper.Handler, userService service.UserService) engine.ControllerBinder {
+	return &binder{
+		AuthMiddleware: authMiddleware,
+		UserService:    userService,
+	}
+}

--- a/src/api/controller/user/user_binder_test.go
+++ b/src/api/controller/user/user_binder_test.go
@@ -1,0 +1,51 @@
+package user_test
+
+import (
+	"github.com/arpb2/C-3PO/src/api/controller"
+	"github.com/arpb2/C-3PO/src/api/controller/user"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type MockControllerRegistrable struct{
+	RegisteredControllers []controller.Controller
+}
+
+func (m *MockControllerRegistrable) Register(controller controller.Controller) {
+	m.RegisteredControllers = append(m.RegisteredControllers, controller)
+}
+
+func bindControllers() *MockControllerRegistrable {
+	binder := user.CreateBinder(nil, nil)
+	registrable := &MockControllerRegistrable{}
+
+	binder.BindControllers(registrable)
+
+	return registrable
+}
+
+func lookupController(path string) controller.Controller {
+	registrable := bindControllers()
+	var expectedController controller.Controller
+
+	for _, registeredController := range registrable.RegisteredControllers {
+		if registeredController.Path == path {
+			expectedController = registeredController
+		}
+	}
+
+	return expectedController
+}
+
+func TestCreateBinder_RegistersRoutes(t *testing.T) {
+	assert.NotNil(t, lookupController("GET"))
+	assert.NotNil(t, lookupController("POST"))
+	assert.NotNil(t, lookupController("PUT"))
+	assert.NotNil(t, lookupController("DELETE"))
+}
+
+func TestCreateBinder_RegistersOnlyRoutes(t *testing.T) {
+	registrable := bindControllers()
+
+	assert.Equal(t, 4, len(registrable.RegisteredControllers))
+}

--- a/src/api/controller/user/user_controller.go
+++ b/src/api/controller/user/user_controller.go
@@ -1,26 +1,12 @@
 package user
 
 import (
-	"github.com/arpb2/C-3PO/src/api/auth/jwt"
 	"github.com/arpb2/C-3PO/src/api/controller"
-	"github.com/arpb2/C-3PO/src/api/engine"
 	"github.com/arpb2/C-3PO/src/api/http_wrapper"
-	"github.com/arpb2/C-3PO/src/api/middleware/auth/single_auth"
 	"github.com/arpb2/C-3PO/src/api/model"
-	"github.com/arpb2/C-3PO/src/api/service/user_service"
 	"net/http"
 	"strconv"
 )
-
-func Binder(handler engine.ControllerRegistrable) {
-	authMiddleware := single_auth.CreateMiddleware(jwt.CreateTokenHandler())
-	userService := user_service.GetService()
-
-	handler.Register(CreateGetController(authMiddleware, userService))
-	handler.Register(CreatePostController(authMiddleware, userService))
-	handler.Register(CreatePutController(authMiddleware, userService))
-	handler.Register(CreateDeleteController(authMiddleware, userService))
-}
 
 func FetchUserId(ctx *http_wrapper.Context) (uint, bool) {
 	userId := ctx.GetParameter("user_id")

--- a/src/api/controller/user/user_delete_controller_test.go
+++ b/src/api/controller/user/user_delete_controller_test.go
@@ -21,7 +21,7 @@ func createDeleteController() controller.Controller {
 		single_auth.CreateMiddleware(
 			jwt.CreateTokenHandler(),
 		),
-		user_service.GetService(),
+		user_service.CreateService(),
 	)
 }
 

--- a/src/api/controller/user/user_get_controller_test.go
+++ b/src/api/controller/user/user_get_controller_test.go
@@ -22,7 +22,7 @@ func createGetController() controller.Controller {
 		single_auth.CreateMiddleware(
 			jwt.CreateTokenHandler(),
 		),
-		user_service.GetService(),
+		user_service.CreateService(),
 	)
 }
 

--- a/src/api/controller/user/user_post_controller.go
+++ b/src/api/controller/user/user_post_controller.go
@@ -7,13 +7,10 @@ import (
 	"net/http"
 )
 
-func CreatePostController(authMiddleware http_wrapper.Handler, userService service.UserService) controller.Controller {
+func CreatePostController(userService service.UserService) controller.Controller {
 	return controller.Controller{
 		Method: "POST",
 		Path:   "/users",
-		Middleware: []http_wrapper.Handler{
-			authMiddleware,
-		},
 		Body: CreatePostBody(userService),
 	}
 }

--- a/src/api/controller/user/user_post_controller_test.go
+++ b/src/api/controller/user/user_post_controller_test.go
@@ -3,13 +3,11 @@ package user_test
 import (
 	"bytes"
 	"errors"
-	"github.com/arpb2/C-3PO/src/api/auth/jwt"
 	"github.com/arpb2/C-3PO/src/api/controller"
 	"github.com/arpb2/C-3PO/src/api/controller/user"
 	"github.com/arpb2/C-3PO/src/api/golden"
 	"github.com/arpb2/C-3PO/src/api/http_wrapper"
 	"github.com/arpb2/C-3PO/src/api/http_wrapper/gin_wrapper"
-	"github.com/arpb2/C-3PO/src/api/middleware/auth/single_auth"
 	"github.com/arpb2/C-3PO/src/api/model"
 	"github.com/arpb2/C-3PO/src/api/service/user_service"
 	"github.com/stretchr/testify/assert"
@@ -19,12 +17,7 @@ import (
 )
 
 func createPostController() controller.Controller {
-	return user.CreatePostController(
-		single_auth.CreateMiddleware(
-			jwt.CreateTokenHandler(),
-		),
-		user_service.GetService(),
-	)
+	return user.CreatePostController(user_service.CreateService())
 }
 
 func TestUserPostControllerMethodIsPOST(t *testing.T) {

--- a/src/api/controller/user/user_put_controller_test.go
+++ b/src/api/controller/user/user_put_controller_test.go
@@ -23,7 +23,7 @@ func createPutController() controller.Controller {
 		single_auth.CreateMiddleware(
 			jwt.CreateTokenHandler(),
 		),
-		user_service.GetService(),
+		user_service.CreateService(),
 	)
 }
 

--- a/src/api/engine/engine.go
+++ b/src/api/engine/engine.go
@@ -17,3 +17,7 @@ type ServerEngine interface {
 type ControllerRegistrable interface {
 	Register(controller controller.Controller)
 }
+
+type ControllerBinder interface {
+	BindControllers(controllerRegistrable ControllerRegistrable)
+}

--- a/src/api/server/server_test.go
+++ b/src/api/server/server_test.go
@@ -56,7 +56,7 @@ func TestStartApplicationFailureIsHandled(t *testing.T) {
 
 func TestHealthGet(test *testing.T) {
 	engine := gin_engine.New()
-	server.RegisterRoutes(engine)
+	server.RegisterRoutes(engine, server.CreateBinders())
 
 	w := performRequest(engine, "GET", "/ping", "")
 
@@ -66,7 +66,7 @@ func TestHealthGet(test *testing.T) {
 
 func TestCodeGetRegistered(test *testing.T) {
 	engine := gin_engine.New()
-	server.RegisterRoutes(engine)
+	server.RegisterRoutes(engine, server.CreateBinders())
 
 	w := performRequest(engine, "GET", "/users/1/codes/1", "")
 
@@ -75,7 +75,7 @@ func TestCodeGetRegistered(test *testing.T) {
 
 func TestCodePostRegistered(test *testing.T) {
 	engine := gin_engine.New()
-	server.RegisterRoutes(engine)
+	server.RegisterRoutes(engine, server.CreateBinders())
 
 	w := performRequest(engine, "POST", "/users/1/codes", "")
 
@@ -84,7 +84,7 @@ func TestCodePostRegistered(test *testing.T) {
 
 func TestCodePutRegistered(test *testing.T) {
 	engine := gin_engine.New()
-	server.RegisterRoutes(engine)
+	server.RegisterRoutes(engine, server.CreateBinders())
 
 	w := performRequest(engine, "PUT", "/users/1/codes/1", "")
 
@@ -93,7 +93,7 @@ func TestCodePutRegistered(test *testing.T) {
 
 func TestUserGetRegistered(test *testing.T) {
 	engine := gin_engine.New()
-	server.RegisterRoutes(engine)
+	server.RegisterRoutes(engine, server.CreateBinders())
 
 	w := performRequest(engine, "GET", "/users/1", "")
 
@@ -102,7 +102,7 @@ func TestUserGetRegistered(test *testing.T) {
 
 func TestUserPostRegistered(test *testing.T) {
 	engine := gin_engine.New()
-	server.RegisterRoutes(engine)
+	server.RegisterRoutes(engine, server.CreateBinders())
 
 	w := performRequest(engine, "POST", "/users", "")
 
@@ -111,7 +111,7 @@ func TestUserPostRegistered(test *testing.T) {
 
 func TestUserPutRegistered(test *testing.T) {
 	engine := gin_engine.New()
-	server.RegisterRoutes(engine)
+	server.RegisterRoutes(engine, server.CreateBinders())
 
 	w := performRequest(engine, "PUT", "/users/1", "")
 
@@ -120,7 +120,7 @@ func TestUserPutRegistered(test *testing.T) {
 
 func TestUserDeleteRegistered(test *testing.T) {
 	engine := gin_engine.New()
-	server.RegisterRoutes(engine)
+	server.RegisterRoutes(engine, server.CreateBinders())
 
 	w := performRequest(engine, "DELETE", "/users/1", "")
 

--- a/src/api/service/code_service/code_service.go
+++ b/src/api/service/code_service/code_service.go
@@ -2,29 +2,25 @@ package code_service
 
 import "github.com/arpb2/C-3PO/src/api/service"
 
-func GetService() service.CodeService {
-	return globalRef
+func CreateService() service.CodeService {
+	return &codeService{}
 }
 
-var globalRef = &codeService{
-	InMemory: map[uint]map[uint]*string{}, // TODO Same as below
-}
+var inMemory = map[uint]map[uint]*string{} // TODO: For the moment (for testing) is a super simple single in-memory holder without err handling as userId:codeId:code
 
-type codeService struct {
-	InMemory map[uint]map[uint]*string // TODO: For the moment (for testing) is a super simple single in-memory holder without err handling as userId:codeId:code
-}
+type codeService struct{}
 func (c *codeService) GetCode(userId uint, codeId uint) (code *string, err error) {
-	return c.InMemory[userId][codeId], nil
+	return inMemory[userId][codeId], nil
 }
 
 func (c *codeService) CreateCode(userId uint, code *string) (codeId uint, err error) {
-	c.InMemory[userId] = map[uint]*string{}
-	c.InMemory[userId][1] = code
+	inMemory[userId] = map[uint]*string{}
+	inMemory[userId][1] = code
 	return 1, nil
 }
 
 func (c *codeService) ReplaceCode(userId uint, codeId uint, code *string) error {
-	c.InMemory[userId] = map[uint]*string{}
-	c.InMemory[userId][1] = code
+	inMemory[userId] = map[uint]*string{}
+	inMemory[userId][1] = code
 	return nil
 }

--- a/src/api/service/teacher_service/teacher_service.go
+++ b/src/api/service/teacher_service/teacher_service.go
@@ -3,15 +3,12 @@ package teacher_service
 import (
 	"github.com/arpb2/C-3PO/src/api/model"
 	"github.com/arpb2/C-3PO/src/api/service"
-	"github.com/arpb2/C-3PO/src/api/service/user_service"
 )
 
-func GetService() service.TeacherService {
-	return globalRef
-}
-
-var globalRef = &teacherService{
-	UserService: user_service.GetService(),
+func CreateService(userService service.UserService) service.TeacherService {
+	return &teacherService{
+		UserService: userService,
+	}
 }
 
 type teacherService struct {

--- a/src/api/service/user_service/user_service.go
+++ b/src/api/service/user_service/user_service.go
@@ -5,11 +5,9 @@ import (
 	"github.com/arpb2/C-3PO/src/api/service"
 )
 
-func GetService() service.UserService {
-	return globalRef
+func CreateService() service.UserService {
+	return &userService{}
 }
-
-var globalRef = &userService{}
 
 type userService struct {}
 func (u userService) GetUser(userId uint) (user *model.User, err error) {

--- a/src/api/test_integration/code_controller_test.go
+++ b/src/api/test_integration/code_controller_test.go
@@ -42,7 +42,7 @@ func Test_Get(t *testing.T) {
 
 	// Add code to retrieve
 	code := "expected code"
-	codeId, err := code_service.GetService().CreateCode(uint(1000), &code)
+	codeId, err := code_service.CreateService().CreateCode(uint(1000), &code)
 
 	assert.Nil(t, err)
 
@@ -119,7 +119,7 @@ func Test_Put(t *testing.T) {
 
 	// Add code to replace
 	code := "test code"
-	codeId, err := code_service.GetService().CreateCode(uint(1000), &code)
+	codeId, err := code_service.CreateService().CreateCode(uint(1000), &code)
 
 	assert.Nil(t, err)
 


### PR DESCRIPTION
Closes #30 

- Change Binder into an interface to allow state (`ControllerState`)
- Add binder implementations on each controller, requiring in the
constructor func whatever they desire
- Build the tree graph from the server (main entry-point) with all the
dependencies
- Change service implementations into normal instances (previously they
    were singletons)
- Remove authentication from POST /users (it doesn't make sense)