### PR TITLE
Level CRUD

### DIFF
--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -52,6 +52,7 @@ services:
         environment:
             - MYSQL_DSN=santi:santipassword@tcp(database:3380)/testdb # TODO remove from here before going live
             - SECRET_JWT=dbe0d0499ecf76fb40821c7c9a705254b15d4db4f9a637023406cb2b425ec622 # TODO remove from here before going live
+            - SECRET_TOKEN_ADMIN=secret-token-admin-stub # TODO remove from here before going live
         build:
             context: ../..
             dockerfile: build/docker/Dockerfile

--- a/pkg/presentation/level/controller/level_get_controller.go
+++ b/pkg/presentation/level/controller/level_get_controller.go
@@ -1,0 +1,18 @@
+package controller
+
+import (
+	"github.com/arpb2/C-3PO/pkg/domain/controller"
+	"github.com/arpb2/C-3PO/pkg/domain/http"
+)
+
+func CreateGetController() controller.Controller {
+	return controller.Controller{
+		Method: "GET",
+		Path:   "/levels/:id",
+		Body:   get,
+	}
+}
+
+func get(ctx *http.Context) {
+	ctx.WriteString(200, "stub")
+}

--- a/pkg/presentation/level/controller/level_get_controller_test.go
+++ b/pkg/presentation/level/controller/level_get_controller_test.go
@@ -1,0 +1,35 @@
+package controller_test
+
+import (
+	"testing"
+
+	"github.com/arpb2/C-3PO/pkg/domain/controller"
+	"github.com/arpb2/C-3PO/pkg/domain/http"
+	level "github.com/arpb2/C-3PO/pkg/presentation/level/controller"
+	httpmock "github.com/arpb2/C-3PO/test/mock/http"
+	"github.com/stretchr/testify/assert"
+)
+
+func createGetController() controller.Controller {
+	return level.CreateGetController()
+}
+
+func TestGetController_IsGet(t *testing.T) {
+	assert.Equal(t, "GET", createGetController().Method)
+}
+
+func TestGetControllerPath_IsLevels(t *testing.T) {
+	assert.Equal(t, "/levels/:id", createGetController().Path)
+}
+
+func TestGetController_IsStubbed(t *testing.T) {
+	writer := new(httpmock.MockWriter)
+	writer.On("WriteString", 200, "stub").Once()
+	ctx := &http.Context{
+		Writer: writer,
+	}
+
+	createGetController().Body(ctx)
+
+	writer.AssertExpectations(t)
+}

--- a/pkg/presentation/level/controller/level_get_controller_test.go
+++ b/pkg/presentation/level/controller/level_get_controller_test.go
@@ -24,7 +24,7 @@ func TestGetControllerPath_IsLevels(t *testing.T) {
 
 func TestGetController_IsStubbed(t *testing.T) {
 	writer := new(httpmock.MockWriter)
-	writer.On("WriteString", 200, "stub").Once()
+	writer.On("WriteString", 200, "stub", []interface{}(nil)).Once()
 	ctx := &http.Context{
 		Writer: writer,
 	}

--- a/pkg/presentation/level/controller/level_put_controller.go
+++ b/pkg/presentation/level/controller/level_put_controller.go
@@ -1,0 +1,21 @@
+package controller
+
+import (
+	"github.com/arpb2/C-3PO/pkg/domain/controller"
+	"github.com/arpb2/C-3PO/pkg/domain/http"
+)
+
+func CreatePutController(authMiddleware http.Handler) controller.Controller {
+	return controller.Controller{
+		Method: "PUT",
+		Path:   "/levels/:id",
+		Middleware: []http.Handler{
+			authMiddleware,
+		},
+		Body: put,
+	}
+}
+
+func put(ctx *http.Context) {
+	ctx.WriteString(200, "stub")
+}

--- a/pkg/presentation/level/controller/level_put_controller_test.go
+++ b/pkg/presentation/level/controller/level_put_controller_test.go
@@ -26,7 +26,7 @@ func TestPutControllerPath_IsLevels(t *testing.T) {
 
 func TestPutController_IsStubbed(t *testing.T) {
 	writer := new(httpmock.MockWriter)
-	writer.On("WriteString", 200, "stub").Once()
+	writer.On("WriteString", 200, "stub", []interface{}(nil)).Once()
 	ctx := &http.Context{
 		Writer: writer,
 	}

--- a/pkg/presentation/level/controller/level_put_controller_test.go
+++ b/pkg/presentation/level/controller/level_put_controller_test.go
@@ -1,0 +1,37 @@
+package controller_test
+
+import (
+	"testing"
+
+	"github.com/arpb2/C-3PO/pkg/domain/controller"
+	"github.com/arpb2/C-3PO/pkg/domain/http"
+	level "github.com/arpb2/C-3PO/pkg/presentation/level/controller"
+	httpmock "github.com/arpb2/C-3PO/test/mock/http"
+	"github.com/stretchr/testify/assert"
+)
+
+func createPutController() controller.Controller {
+	return level.CreatePutController(func(ctx *http.Context) {
+		// Empty
+	})
+}
+
+func TestPutController_IsPut(t *testing.T) {
+	assert.Equal(t, "PUT", createPutController().Method)
+}
+
+func TestPutControllerPath_IsLevels(t *testing.T) {
+	assert.Equal(t, "/levels/:id", createPutController().Path)
+}
+
+func TestPutController_IsStubbed(t *testing.T) {
+	writer := new(httpmock.MockWriter)
+	writer.On("WriteString", 200, "stub").Once()
+	ctx := &http.Context{
+		Writer: writer,
+	}
+
+	createPutController().Body(ctx)
+
+	writer.AssertExpectations(t)
+}

--- a/pkg/presentation/middleware/admin/admin_middleware.go
+++ b/pkg/presentation/middleware/admin/admin_middleware.go
@@ -1,0 +1,21 @@
+package admin
+
+import (
+	"bytes"
+
+	"github.com/arpb2/C-3PO/pkg/presentation/middleware"
+
+	"github.com/arpb2/C-3PO/pkg/domain/http"
+)
+
+func CreateMiddleware(secret []byte) http.Handler {
+	return func(ctx *http.Context) {
+		tkn := ctx.GetHeader(middleware.HeaderAuthorization)
+
+		if len(tkn) == 0 || bytes.Compare([]byte(tkn), secret) != 0 {
+			ctx.AbortTransactionWithError(http.CreateUnauthorizedError())
+		} else {
+			ctx.NextHandler()
+		}
+	}
+}

--- a/pkg/presentation/middleware/admin/admin_middleware_test.go
+++ b/pkg/presentation/middleware/admin/admin_middleware_test.go
@@ -1,0 +1,62 @@
+package admin_test
+
+import (
+	"testing"
+
+	"github.com/arpb2/C-3PO/pkg/presentation/middleware"
+
+	"github.com/arpb2/C-3PO/pkg/domain/http"
+	"github.com/arpb2/C-3PO/pkg/presentation/middleware/admin"
+	httpmock "github.com/arpb2/C-3PO/test/mock/http"
+)
+
+func TestAuthMiddleware_GivenOneWithoutAToken_WhenAuthorizing_ThenItAbortsWithUnauthorized(t *testing.T) {
+	reader := new(httpmock.MockReader)
+	reader.On("GetHeader", middleware.HeaderAuthorization).Return("").Once()
+	middlew := new(httpmock.MockMiddleware)
+	middlew.On("AbortTransactionWithError", http.CreateUnauthorizedError()).Once()
+	ctx := &http.Context{
+		Reader:     reader,
+		Middleware: middlew,
+	}
+	m := admin.CreateMiddleware([]byte("test"))
+
+	m(ctx)
+
+	reader.AssertExpectations(t)
+	middlew.AssertExpectations(t)
+}
+
+func TestAuthMiddleware_GivenOneWithADifferentToken_WhenAuthorizing_ThenItAbortsWithUnauthorized(t *testing.T) {
+	reader := new(httpmock.MockReader)
+	reader.On("GetHeader", middleware.HeaderAuthorization).Return("not test").Once()
+	middlew := new(httpmock.MockMiddleware)
+	middlew.On("AbortTransactionWithError", http.CreateUnauthorizedError()).Once()
+	ctx := &http.Context{
+		Reader:     reader,
+		Middleware: middlew,
+	}
+	m := admin.CreateMiddleware([]byte("test"))
+
+	m(ctx)
+
+	reader.AssertExpectations(t)
+	middlew.AssertExpectations(t)
+}
+
+func TestAuthMiddleware_GivenOneWithTheSameSecretAsToken_WhenAuthorizing_ThenItContinuesTransaction(t *testing.T) {
+	reader := new(httpmock.MockReader)
+	reader.On("GetHeader", middleware.HeaderAuthorization).Return("test").Once()
+	middlew := new(httpmock.MockMiddleware)
+	middlew.On("NextHandler").Once()
+	ctx := &http.Context{
+		Reader:     reader,
+		Middleware: middlew,
+	}
+	m := admin.CreateMiddleware([]byte("test"))
+
+	m(ctx)
+
+	reader.AssertExpectations(t)
+	middlew.AssertExpectations(t)
+}

--- a/pkg/presentation/middleware/constants.go
+++ b/pkg/presentation/middleware/constants.go
@@ -1,0 +1,5 @@
+package middleware
+
+const (
+	HeaderAuthorization = "Authorization"
+)

--- a/pkg/presentation/middleware/user/authentication_handler.go
+++ b/pkg/presentation/middleware/user/authentication_handler.go
@@ -1,8 +1,10 @@
-package middleware
+package user
 
 import (
 	"fmt"
 	"strconv"
+
+	"github.com/arpb2/C-3PO/pkg/presentation/middleware"
 
 	"github.com/arpb2/C-3PO/pkg/domain/auth"
 	"github.com/arpb2/C-3PO/pkg/domain/http"
@@ -10,7 +12,7 @@ import (
 )
 
 func HandleAuthentication(ctx *http.Context, tokenHandler auth.TokenHandler, strategies ...authmiddleware.AuthenticationStrategy) {
-	authToken := ctx.GetHeader("Authorization")
+	authToken := ctx.GetHeader(middleware.HeaderAuthorization)
 
 	if authToken == "" {
 		ctx.AbortTransactionWithError(http.CreateUnauthorizedError())

--- a/pkg/presentation/middleware/user/authentication_handler_test.go
+++ b/pkg/presentation/middleware/user/authentication_handler_test.go
@@ -1,4 +1,4 @@
-package middleware_test
+package user_test
 
 import (
 	"errors"
@@ -7,7 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/arpb2/C-3PO/pkg/presentation/auth/middleware"
+	"github.com/arpb2/C-3PO/pkg/presentation/middleware"
+
+	"github.com/arpb2/C-3PO/pkg/presentation/middleware/user"
 
 	internalauth "github.com/arpb2/C-3PO/pkg/data/jwt"
 	"github.com/arpb2/C-3PO/pkg/domain/auth"
@@ -43,7 +45,7 @@ func Test_HandlingOfAuthentication_NoHeader(t *testing.T) {
 		Path:   "/test",
 		Middleware: []httpwrapper.Handler{
 			func(context *httpwrapper.Context) {
-				middleware.HandleAuthentication(context, internalauth.CreateTokenHandler([]byte("52bfd2de0a2e69dff4517518590ac32a46bd76606ec22a258f99584a6e70aca2")))
+				user.HandleAuthentication(context, internalauth.CreateTokenHandler([]byte("52bfd2de0a2e69dff4517518590ac32a46bd76606ec22a258f99584a6e70aca2")))
 			},
 		},
 		Body: func(ctx *httpwrapper.Context) {
@@ -64,7 +66,7 @@ func Test_HandlingOfAuthentication_BadHeader(t *testing.T) {
 		Path:   "/test",
 		Middleware: []httpwrapper.Handler{
 			func(context *httpwrapper.Context) {
-				middleware.HandleAuthentication(context, internalauth.CreateTokenHandler([]byte("52bfd2de0a2e69dff4517518590ac32a46bd76606ec22a258f99584a6e70aca2")))
+				user.HandleAuthentication(context, internalauth.CreateTokenHandler([]byte("52bfd2de0a2e69dff4517518590ac32a46bd76606ec22a258f99584a6e70aca2")))
 			},
 		},
 		Body: func(ctx *httpwrapper.Context) {
@@ -73,7 +75,7 @@ func Test_HandlingOfAuthentication_BadHeader(t *testing.T) {
 	})
 
 	headers := map[string][]string{}
-	headers["Authorization"] = []string{"bad token"}
+	headers[middleware.HeaderAuthorization] = []string{"bad token"}
 	recorder := performRequest(e, "GET", "/test", "", headers)
 
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
@@ -87,7 +89,7 @@ func Test_HandlingOfAuthentication_UnauthorizedUser(t *testing.T) {
 		Path:   "/test/:user_id",
 		Middleware: []httpwrapper.Handler{
 			func(context *httpwrapper.Context) {
-				middleware.HandleAuthentication(context, internalauth.CreateTokenHandler([]byte("52bfd2de0a2e69dff4517518590ac32a46bd76606ec22a258f99584a6e70aca2")))
+				user.HandleAuthentication(context, internalauth.CreateTokenHandler([]byte("52bfd2de0a2e69dff4517518590ac32a46bd76606ec22a258f99584a6e70aca2")))
 			},
 		},
 		Body: func(ctx *httpwrapper.Context) {
@@ -97,7 +99,7 @@ func Test_HandlingOfAuthentication_UnauthorizedUser(t *testing.T) {
 
 	headers := map[string][]string{}
 	// Token for user 1000
-	headers["Authorization"] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDB9.GVS-KC5nOCHybzzFIIH864u4KcGu-ZSd-96krqTUGWo"}
+	headers[middleware.HeaderAuthorization] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDB9.GVS-KC5nOCHybzzFIIH864u4KcGu-ZSd-96krqTUGWo"}
 	recorder := performRequest(e, "GET", "/test/1", "", headers)
 
 	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
@@ -111,7 +113,7 @@ func Test_HandlingOfAuthentication_Authorized_SameUser(t *testing.T) {
 		Path:   "/test/:user_id",
 		Middleware: []httpwrapper.Handler{
 			func(context *httpwrapper.Context) {
-				middleware.HandleAuthentication(context, internalauth.CreateTokenHandler([]byte("52bfd2de0a2e69dff4517518590ac32a46bd76606ec22a258f99584a6e70aca2")))
+				user.HandleAuthentication(context, internalauth.CreateTokenHandler([]byte("52bfd2de0a2e69dff4517518590ac32a46bd76606ec22a258f99584a6e70aca2")))
 			},
 		},
 		Body: func(ctx *httpwrapper.Context) {
@@ -121,7 +123,7 @@ func Test_HandlingOfAuthentication_Authorized_SameUser(t *testing.T) {
 
 	headers := map[string][]string{}
 	// Token for user 1000
-	headers["Authorization"] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDB9.GVS-KC5nOCHybzzFIIH864u4KcGu-ZSd-96krqTUGWo"}
+	headers[middleware.HeaderAuthorization] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDB9.GVS-KC5nOCHybzzFIIH864u4KcGu-ZSd-96krqTUGWo"}
 	recorder := performRequest(e, "GET", "/test/1000", "", headers)
 
 	assert.Equal(t, http.StatusOK, recorder.Code)
@@ -140,7 +142,7 @@ func TestStrategy_Error_Halts(t *testing.T) {
 		Path:   "/test/:user_id",
 		Middleware: []httpwrapper.Handler{
 			func(context *httpwrapper.Context) {
-				middleware.HandleAuthentication(context, internalauth.CreateTokenHandler([]byte("52bfd2de0a2e69dff4517518590ac32a46bd76606ec22a258f99584a6e70aca2")), strategy)
+				user.HandleAuthentication(context, internalauth.CreateTokenHandler([]byte("52bfd2de0a2e69dff4517518590ac32a46bd76606ec22a258f99584a6e70aca2")), strategy)
 			},
 		},
 		Body: func(ctx *httpwrapper.Context) {
@@ -150,7 +152,7 @@ func TestStrategy_Error_Halts(t *testing.T) {
 
 	headers := map[string][]string{}
 	// Token for user 1000
-	headers["Authorization"] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDB9.GVS-KC5nOCHybzzFIIH864u4KcGu-ZSd-96krqTUGWo"}
+	headers[middleware.HeaderAuthorization] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDB9.GVS-KC5nOCHybzzFIIH864u4KcGu-ZSd-96krqTUGWo"}
 	recorder := performRequest(e, "GET", "/test/1001", "", headers)
 
 	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
@@ -170,7 +172,7 @@ func TestStrategy_Unauthorized_Halts(t *testing.T) {
 		Path:   "/test/:user_id",
 		Middleware: []httpwrapper.Handler{
 			func(context *httpwrapper.Context) {
-				middleware.HandleAuthentication(context, internalauth.CreateTokenHandler([]byte("52bfd2de0a2e69dff4517518590ac32a46bd76606ec22a258f99584a6e70aca2")), strategy)
+				user.HandleAuthentication(context, internalauth.CreateTokenHandler([]byte("52bfd2de0a2e69dff4517518590ac32a46bd76606ec22a258f99584a6e70aca2")), strategy)
 			},
 		},
 		Body: func(ctx *httpwrapper.Context) {
@@ -180,7 +182,7 @@ func TestStrategy_Unauthorized_Halts(t *testing.T) {
 
 	headers := map[string][]string{}
 	// Token for user 1000
-	headers["Authorization"] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDB9.GVS-KC5nOCHybzzFIIH864u4KcGu-ZSd-96krqTUGWo"}
+	headers[middleware.HeaderAuthorization] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDB9.GVS-KC5nOCHybzzFIIH864u4KcGu-ZSd-96krqTUGWo"}
 	recorder := performRequest(e, "GET", "/test/1001", "", headers)
 
 	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
@@ -200,7 +202,7 @@ func TestStrategy_Authorized_Continues(t *testing.T) {
 		Path:   "/test/:user_id",
 		Middleware: []httpwrapper.Handler{
 			func(context *httpwrapper.Context) {
-				middleware.HandleAuthentication(context, internalauth.CreateTokenHandler([]byte("52bfd2de0a2e69dff4517518590ac32a46bd76606ec22a258f99584a6e70aca2")), strategy)
+				user.HandleAuthentication(context, internalauth.CreateTokenHandler([]byte("52bfd2de0a2e69dff4517518590ac32a46bd76606ec22a258f99584a6e70aca2")), strategy)
 			},
 		},
 		Body: func(ctx *httpwrapper.Context) {
@@ -210,7 +212,7 @@ func TestStrategy_Authorized_Continues(t *testing.T) {
 
 	headers := map[string][]string{}
 	// Token for user 1000
-	headers["Authorization"] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDB9.GVS-KC5nOCHybzzFIIH864u4KcGu-ZSd-96krqTUGWo"}
+	headers[middleware.HeaderAuthorization] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDB9.GVS-KC5nOCHybzzFIIH864u4KcGu-ZSd-96krqTUGWo"}
 	recorder := performRequest(e, "GET", "/test/1001", "", headers)
 
 	assert.Equal(t, http.StatusOK, recorder.Code)

--- a/pkg/presentation/middleware/user/single/single_authentication_middleware.go
+++ b/pkg/presentation/middleware/user/single/single_authentication_middleware.go
@@ -3,11 +3,11 @@ package single
 import (
 	"github.com/arpb2/C-3PO/pkg/domain/auth"
 	"github.com/arpb2/C-3PO/pkg/domain/http"
-	"github.com/arpb2/C-3PO/pkg/presentation/auth/middleware"
+	"github.com/arpb2/C-3PO/pkg/presentation/middleware/user"
 )
 
 func CreateMiddleware(tokenHandler auth.TokenHandler) http.Handler {
 	return func(ctx *http.Context) {
-		middleware.HandleAuthentication(ctx, tokenHandler)
+		user.HandleAuthentication(ctx, tokenHandler)
 	}
 }

--- a/pkg/presentation/middleware/user/single/single_authentication_middleware_test.go
+++ b/pkg/presentation/middleware/user/single/single_authentication_middleware_test.go
@@ -6,11 +6,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/arpb2/C-3PO/pkg/presentation/middleware"
+
 	"github.com/arpb2/C-3PO/pkg/data/jwt"
 	"github.com/arpb2/C-3PO/pkg/domain/controller"
 	httpwrapper "github.com/arpb2/C-3PO/pkg/domain/http"
 	ginengine "github.com/arpb2/C-3PO/pkg/infra/engine/gin"
-	"github.com/arpb2/C-3PO/pkg/presentation/auth/middleware/single"
+	"github.com/arpb2/C-3PO/pkg/presentation/middleware/user/single"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -58,7 +60,7 @@ func Test_Single_HandlingOfAuthentication_BadHeader(t *testing.T) {
 	})
 
 	headers := map[string][]string{}
-	headers["Authorization"] = []string{"bad token"}
+	headers[middleware.HeaderAuthorization] = []string{"bad token"}
 	recorder := performRequest(e, "GET", "/test", "", headers)
 
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
@@ -80,7 +82,7 @@ func Test_Single_HandlingOfAuthentication_UnauthorizedUser(t *testing.T) {
 
 	headers := map[string][]string{}
 	// Token for user 1000
-	headers["Authorization"] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDB9.GVS-KC5nOCHybzzFIIH864u4KcGu-ZSd-96krqTUGWo"}
+	headers[middleware.HeaderAuthorization] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDB9.GVS-KC5nOCHybzzFIIH864u4KcGu-ZSd-96krqTUGWo"}
 	recorder := performRequest(e, "GET", "/test/1", "", headers)
 
 	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
@@ -102,7 +104,7 @@ func Test_Single_HandlingOfAuthentication_Authorized_SameUser(t *testing.T) {
 
 	headers := map[string][]string{}
 	// Token for user 1000
-	headers["Authorization"] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDB9.GVS-KC5nOCHybzzFIIH864u4KcGu-ZSd-96krqTUGWo"}
+	headers[middleware.HeaderAuthorization] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDB9.GVS-KC5nOCHybzzFIIH864u4KcGu-ZSd-96krqTUGWo"}
 	recorder := performRequest(e, "GET", "/test/1000", "", headers)
 
 	assert.Equal(t, http.StatusOK, recorder.Code)

--- a/pkg/presentation/middleware/user/teacher/user_or_teacher_authentication_middleware.go
+++ b/pkg/presentation/middleware/user/teacher/user_or_teacher_authentication_middleware.go
@@ -3,7 +3,7 @@ package teacher
 import (
 	"strconv"
 
-	"github.com/arpb2/C-3PO/pkg/presentation/auth/middleware"
+	"github.com/arpb2/C-3PO/pkg/presentation/middleware/user"
 
 	"github.com/arpb2/C-3PO/pkg/domain/auth"
 	"github.com/arpb2/C-3PO/pkg/domain/http"
@@ -16,7 +16,7 @@ func CreateMiddleware(tokenHandler auth.TokenHandler, teacherService teacherserv
 	}
 
 	return func(ctx *http.Context) {
-		middleware.HandleAuthentication(ctx, tokenHandler, strategy)
+		user.HandleAuthentication(ctx, tokenHandler, strategy)
 	}
 }
 

--- a/pkg/presentation/middleware/user/teacher/user_or_teacher_authentication_middleware_test.go
+++ b/pkg/presentation/middleware/user/teacher/user_or_teacher_authentication_middleware_test.go
@@ -7,12 +7,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/arpb2/C-3PO/pkg/presentation/middleware"
+
 	"github.com/arpb2/C-3PO/pkg/data/jwt"
 	"github.com/arpb2/C-3PO/pkg/domain/controller"
 	httpwrapper "github.com/arpb2/C-3PO/pkg/domain/http"
 	"github.com/arpb2/C-3PO/pkg/domain/model"
 	ginengine "github.com/arpb2/C-3PO/pkg/infra/engine/gin"
-	"github.com/arpb2/C-3PO/pkg/presentation/auth/middleware/teacher"
+	"github.com/arpb2/C-3PO/pkg/presentation/middleware/user/teacher"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -93,7 +95,7 @@ func Test_Multi_HandlingOfAuthentication_BadHeader(t *testing.T) {
 	})
 
 	headers := map[string][]string{}
-	headers["Authorization"] = []string{"bad token"}
+	headers[middleware.HeaderAuthorization] = []string{"bad token"}
 	recorder := performRequest(e, "GET", "/test", "", headers)
 
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
@@ -118,7 +120,7 @@ func Test_Multi_HandlingOfAuthentication_UnauthorizedUser(t *testing.T) {
 
 	headers := map[string][]string{}
 	// Token for user 1000
-	headers["Authorization"] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDB9.GVS-KC5nOCHybzzFIIH864u4KcGu-ZSd-96krqTUGWo"}
+	headers[middleware.HeaderAuthorization] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDB9.GVS-KC5nOCHybzzFIIH864u4KcGu-ZSd-96krqTUGWo"}
 	recorder := performRequest(e, "GET", "/test/1", "", headers)
 
 	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
@@ -142,7 +144,7 @@ func Test_Multi_HandlingOfAuthentication_Authorized_SameUser(t *testing.T) {
 
 	headers := map[string][]string{}
 	// Token for user 1000
-	headers["Authorization"] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDB9.GVS-KC5nOCHybzzFIIH864u4KcGu-ZSd-96krqTUGWo"}
+	headers[middleware.HeaderAuthorization] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDB9.GVS-KC5nOCHybzzFIIH864u4KcGu-ZSd-96krqTUGWo"}
 	recorder := performRequest(e, "GET", "/test/1000", "", headers)
 
 	assert.Equal(t, http.StatusOK, recorder.Code)
@@ -174,7 +176,7 @@ func Test_Multi_HandlingOfAuthentication_Authorized_Student(t *testing.T) {
 
 	headers := map[string][]string{}
 	// Token for user 1001
-	headers["Authorization"] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDF9.Vx0MXNKC_A5s7rWZ_LfcwEc7rVgbns62mfFbq3RwSk0"}
+	headers[middleware.HeaderAuthorization] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDF9.Vx0MXNKC_A5s7rWZ_LfcwEc7rVgbns62mfFbq3RwSk0"}
 	recorder := performRequest(e, "GET", "/test/1000", "", headers)
 
 	assert.Equal(t, http.StatusOK, recorder.Code)
@@ -210,7 +212,7 @@ func Test_Multi_HandlingOfAuthentication_Unauthorized_Student(t *testing.T) {
 
 	headers := map[string][]string{}
 	// Token for user 1002
-	headers["Authorization"] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDJ9.YRQ2drFXz-apv85QOyMjNybmxsizVnfwImTWKwIVqso"}
+	headers[middleware.HeaderAuthorization] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDJ9.YRQ2drFXz-apv85QOyMjNybmxsizVnfwImTWKwIVqso"}
 	recorder := performRequest(e, "GET", "/test/1000", "", headers)
 
 	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
@@ -236,7 +238,7 @@ func Test_Multi_HandlingOfAuthentication_Service_Error(t *testing.T) {
 
 	headers := map[string][]string{}
 	// Token for user 1001
-	headers["Authorization"] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDF9.Vx0MXNKC_A5s7rWZ_LfcwEc7rVgbns62mfFbq3RwSk0"}
+	headers[middleware.HeaderAuthorization] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOjEwMDF9.Vx0MXNKC_A5s7rWZ_LfcwEc7rVgbns62mfFbq3RwSk0"}
 	recorder := performRequest(e, "GET", "/test/1000", "", headers)
 
 	assert.Equal(t, http.StatusInternalServerError, recorder.Code)

--- a/pkg/presentation/user/controller/user_delete_controller_test.go
+++ b/pkg/presentation/user/controller/user_delete_controller_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/arpb2/C-3PO/pkg/data/jwt"
 	"github.com/arpb2/C-3PO/pkg/domain/controller"
 	"github.com/arpb2/C-3PO/pkg/infra/executor"
-	"github.com/arpb2/C-3PO/pkg/presentation/auth/middleware/single"
+	"github.com/arpb2/C-3PO/pkg/presentation/middleware/user/single"
 	"github.com/arpb2/C-3PO/test/mock/golden"
 	testhttpwrapper "github.com/arpb2/C-3PO/test/mock/http"
 	"github.com/arpb2/C-3PO/test/mock/service"

--- a/pkg/presentation/user/controller/user_get_controller_test.go
+++ b/pkg/presentation/user/controller/user_get_controller_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/arpb2/C-3PO/pkg/domain/controller"
 	"github.com/arpb2/C-3PO/pkg/domain/model"
 	"github.com/arpb2/C-3PO/pkg/infra/executor"
-	"github.com/arpb2/C-3PO/pkg/presentation/auth/middleware/single"
+	"github.com/arpb2/C-3PO/pkg/presentation/middleware/user/single"
 	"github.com/arpb2/C-3PO/test/mock/golden"
 	testhttpwrapper "github.com/arpb2/C-3PO/test/mock/http"
 	"github.com/arpb2/C-3PO/test/mock/service"

--- a/pkg/presentation/user/controller/user_put_controller_test.go
+++ b/pkg/presentation/user/controller/user_put_controller_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/arpb2/C-3PO/pkg/domain/controller"
 	"github.com/arpb2/C-3PO/pkg/domain/model"
 	"github.com/arpb2/C-3PO/pkg/infra/executor"
-	"github.com/arpb2/C-3PO/pkg/presentation/auth/middleware/single"
+	"github.com/arpb2/C-3PO/pkg/presentation/middleware/user/single"
 	"github.com/arpb2/C-3PO/test/mock/golden"
 	testhttpwrapper "github.com/arpb2/C-3PO/test/mock/http"
 	"github.com/arpb2/C-3PO/test/mock/service"

--- a/pkg/presentation/user_level/controller/user_level_get_controller_test.go
+++ b/pkg/presentation/user_level/controller/user_level_get_controller_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/arpb2/C-3PO/pkg/domain/controller"
 	"github.com/arpb2/C-3PO/pkg/domain/model"
 	"github.com/arpb2/C-3PO/pkg/infra/executor"
-	"github.com/arpb2/C-3PO/pkg/presentation/auth/middleware/teacher"
+	"github.com/arpb2/C-3PO/pkg/presentation/middleware/user/teacher"
 	"github.com/arpb2/C-3PO/test/mock/golden"
 	testhttpwrapper "github.com/arpb2/C-3PO/test/mock/http"
 	"github.com/arpb2/C-3PO/test/mock/service"

--- a/pkg/presentation/user_level/controller/user_level_put_controller_test.go
+++ b/pkg/presentation/user_level/controller/user_level_put_controller_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/arpb2/C-3PO/pkg/domain/controller"
 	"github.com/arpb2/C-3PO/pkg/domain/model"
 	"github.com/arpb2/C-3PO/pkg/infra/executor"
-	"github.com/arpb2/C-3PO/pkg/presentation/auth/middleware/teacher"
+	"github.com/arpb2/C-3PO/pkg/presentation/middleware/user/teacher"
 	"github.com/arpb2/C-3PO/test/mock/golden"
 	testhttpwrapper "github.com/arpb2/C-3PO/test/mock/http"
 	"github.com/arpb2/C-3PO/test/mock/service"


### PR DESCRIPTION
- Create controllers for Level CRUD (only put and get)
- Add middleware for admin only operation (level PUT is only accesible by admin) -> We won't do a privilege structure because it's too much unneeded complexity
- Register components
- Refactor directories for better visibility