### PR TITLE
Add level definitions

### DIFF
--- a/pkg/data/usecase/level/write_level_usecase.go
+++ b/pkg/data/usecase/level/write_level_usecase.go
@@ -26,13 +26,13 @@ func (c *writeLevelUseCase) Run(ctx pipeline.Context) error {
 	}
 
 	levelData.Id = levelId
-	level, err := c.repository.StoreLevel(levelData)
+	lvl, err := c.repository.StoreLevel(levelData)
 
 	if err != nil {
 		return err
 	}
 
-	ctx.Set(TagLevel, level)
+	ctx.Set(TagLevel, lvl)
 	return nil
 }
 

--- a/pkg/domain/model/level/definition.go
+++ b/pkg/domain/model/level/definition.go
@@ -1,0 +1,60 @@
+package level
+
+const (
+	OrientationNorth Orientation = "N"
+	OrientationSouth Orientation = "S"
+	OrientationEast  Orientation = "E"
+	OrientationWest  Orientation = "W"
+
+	AxisX Axis = "x"
+	AxisY Axis = "y"
+)
+
+type Definition struct {
+	Origin           Origin      `json:"origin"`
+	Destination      Destination `json:"destination"`
+	MinimalDimension Dimension   `json:"minimal_dimension"`
+	Collectibles     []Element   `json:"collectibles"`
+	Gates            []Gate      `json:"gates"`
+	Pads             []Element   `json:"pads"`
+}
+
+type Orientation string
+type Axis string
+
+type Origin struct {
+	Position    Position    `json:"position"`
+	Orientation Orientation `json:"orientation"`
+}
+
+type Position struct {
+	X    int  `json:"x"`
+	Y    int  `json:"y"`
+	Axis Axis `json:"axis,omitempty"`
+}
+
+type Destination struct {
+	Position   Position    `json:"position"`
+	Active     bool        `json:"active"`
+	Conditions []Condition `json:"conditions"`
+}
+
+type Condition struct {
+	Type  string      `json:"type"`
+	Value interface{} `json:"value"`
+}
+
+type Dimension struct {
+	Rows    int `json:"rows"`
+	Columns int `json:"columns"`
+}
+
+type Element struct {
+	Position Position `json:"position"`
+	Type     string   `json:"type"`
+}
+
+type Gate struct {
+	Element
+	OpeningValue string `json:"opening_value,omitempty"`
+}

--- a/pkg/domain/model/level/definition_test.go
+++ b/pkg/domain/model/level/definition_test.go
@@ -1,0 +1,195 @@
+package level_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	level2 "github.com/arpb2/C-3PO/pkg/domain/model/level"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLevelDefinition_ToJson(t *testing.T) {
+	expectedJson := `{"origin":{"position":{"x":1,"y":2},"orientation":"E"},"destination":{"position":{"x":2,"y":3},"active":true,"conditions":[{"type":"coin","value":3},{"type":"colour","value":"blue"},{"type":"key","value":true}]},"minimal_dimension":{"rows":1,"columns":2},"collectibles":[{"position":{"x":1,"y":2},"type":"coin"},{"position":{"x":4,"y":3},"type":"key"}],"gates":[{"position":{"x":1,"y":2,"axis":"x"},"type":"key"},{"position":{"x":1,"y":8,"axis":"y"},"type":"verbal","opening_value":"holis"}],"pads":[{"position":{"x":1,"y":2},"type":"colour"}]}`
+
+	definition := &level2.Definition{
+		Origin: level2.Origin{
+			Position: level2.Position{
+				X: 1,
+				Y: 2,
+			},
+			Orientation: level2.OrientationEast,
+		},
+		Destination: level2.Destination{
+			Position: level2.Position{
+				X: 2,
+				Y: 3,
+			},
+			Active: true,
+			Conditions: []level2.Condition{
+				{
+					Type:  "coin",
+					Value: float64(3),
+				},
+				{
+					Type:  "colour",
+					Value: "blue",
+				},
+				{
+					Type:  "key",
+					Value: true,
+				},
+			},
+		},
+		MinimalDimension: level2.Dimension{
+			Rows:    1,
+			Columns: 2,
+		},
+		Collectibles: []level2.Element{
+			{
+				Position: level2.Position{
+					X: 1,
+					Y: 2,
+				},
+				Type: "coin",
+			},
+			{
+				Position: level2.Position{
+					X: 4,
+					Y: 3,
+				},
+				Type: "key",
+			},
+		},
+		Gates: []level2.Gate{
+			{
+				Element: level2.Element{
+					Position: level2.Position{
+						X:    1,
+						Y:    2,
+						Axis: level2.AxisX,
+					},
+					Type: "key",
+				},
+			},
+			{
+				Element: level2.Element{
+					Position: level2.Position{
+						X:    1,
+						Y:    8,
+						Axis: level2.AxisY,
+					},
+					Type: "verbal",
+				},
+				OpeningValue: "holis",
+			},
+		},
+		Pads: []level2.Element{
+			{
+				Position: level2.Position{
+					X: 1,
+					Y: 2,
+				},
+				Type: "colour",
+			},
+		},
+	}
+
+	data, err := json.Marshal(definition)
+
+	assert.Nil(t, err)
+	assert.Equal(t, expectedJson, string(data))
+}
+
+func TestLevelDefinition_FromJson(t *testing.T) {
+	data := `{"origin":{"position":{"x":1,"y":2},"orientation":"E"},"destination":{"position":{"x":2,"y":3},"active":true,"conditions":[{"type":"coin","value":3},{"type":"colour","value":"blue"},{"type":"key","value":true}]},"minimal_dimension":{"rows":1,"columns":2},"collectibles":[{"position":{"x":1,"y":2},"type":"coin"},{"position":{"x":4,"y":3},"type":"key"}],"gates":[{"position":{"x":1,"y":2,"axis":"x"},"type":"key"},{"position":{"x":1,"y":8,"axis":"y"},"type":"verbal","opening_value":"holis"}],"pads":[{"position":{"x":1,"y":2},"type":"colour"}]}`
+	expectedDefinition := level2.Definition{
+		Origin: level2.Origin{
+			Position: level2.Position{
+				X: 1,
+				Y: 2,
+			},
+			Orientation: level2.OrientationEast,
+		},
+		Destination: level2.Destination{
+			Position: level2.Position{
+				X: 2,
+				Y: 3,
+			},
+			Active: true,
+			Conditions: []level2.Condition{
+				{
+					Type:  "coin",
+					Value: float64(3),
+				},
+				{
+					Type:  "colour",
+					Value: "blue",
+				},
+				{
+					Type:  "key",
+					Value: true,
+				},
+			},
+		},
+		MinimalDimension: level2.Dimension{
+			Rows:    1,
+			Columns: 2,
+		},
+		Collectibles: []level2.Element{
+			{
+				Position: level2.Position{
+					X: 1,
+					Y: 2,
+				},
+				Type: "coin",
+			},
+			{
+				Position: level2.Position{
+					X: 4,
+					Y: 3,
+				},
+				Type: "key",
+			},
+		},
+		Gates: []level2.Gate{
+			{
+				Element: level2.Element{
+					Position: level2.Position{
+						X:    1,
+						Y:    2,
+						Axis: level2.AxisX,
+					},
+					Type: "key",
+				},
+			},
+			{
+				Element: level2.Element{
+					Position: level2.Position{
+						X:    1,
+						Y:    8,
+						Axis: level2.AxisY,
+					},
+					Type: "verbal",
+				},
+				OpeningValue: "holis",
+			},
+		},
+		Pads: []level2.Element{
+			{
+				Position: level2.Position{
+					X: 1,
+					Y: 2,
+				},
+				Type: "colour",
+			},
+		},
+	}
+	var definition level2.Definition
+
+	err := json.Unmarshal([]byte(data), &definition)
+
+	assert.Nil(t, err)
+
+	assert.Equal(t, expectedDefinition, definition)
+}

--- a/pkg/domain/model/level/level.go
+++ b/pkg/domain/model/level/level.go
@@ -1,7 +1,8 @@
 package level
 
 type Level struct {
-	Id          uint   `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
+	Id          uint       `json:"id"`
+	Name        string     `json:"name"`
+	Description string     `json:"description"`
+	Definition  Definition `json:"definition"`
 }

--- a/pkg/domain/model/level/level_test.go
+++ b/pkg/domain/model/level/level_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestLevel_ToJson(t *testing.T) {
-	expectedJson := `{"id":0,"name":"test name","description":"test description"}`
+	expectedJson := `{"id":0,"name":"test name","description":"test description","definition":{"origin":{"position":{"x":0,"y":0},"orientation":""},"destination":{"position":{"x":0,"y":0},"active":false,"conditions":null},"minimal_dimension":{"rows":0,"columns":0},"collectibles":null,"gates":null,"pads":null}}`
 
 	level := &level2.Level{
 		Id:          0,
@@ -31,7 +31,7 @@ func TestLevel_FromJson(t *testing.T) {
 		Description: "test description",
 	}
 
-	data := `{"id":0,"name":"test name","description":"test description"}`
+	data := `{"id":0,"name":"test name","description":"test description","definition":{"origin":{"position":{"x":0,"y":0},"orientation":""},"destination":{"position":{"x":0,"y":0},"active":false,"conditions":null},"minimal_dimension":{"rows":0,"columns":0},"collectibles":null,"gates":null,"pads":null}}`
 	var level level2.Level
 
 	err := json.Unmarshal([]byte(data), &level)

--- a/pkg/infrastructure/mysql/level/level_repository.go
+++ b/pkg/infrastructure/mysql/level/level_repository.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/arpb2/C-3PO/third_party/ent/schema"
+
 	level2 "github.com/arpb2/C-3PO/pkg/data/repository/level"
 	"github.com/arpb2/C-3PO/pkg/domain/model/level"
 
@@ -63,18 +65,21 @@ func (l *levelRepository) StoreLevel(lvl level.Level) (result level.Level, err e
 		return lvl, err
 	}
 
+	levelDefinition := schema.LevelDefinition(lvl.Definition)
 	if lev == nil {
 		_, err = l.dbClient.Level.
 			Create().
 			SetID(lvl.Id).
 			SetName(lvl.Name).
 			SetDescription(lvl.Description).
+			SetDefinition(&levelDefinition).
 			Save(ctx)
 	} else {
 		_, err = lev.
 			Update().
 			SetName(lvl.Name).
 			SetDescription(lvl.Description).
+			SetDefinition(&levelDefinition).
 			SetUpdatedAt(time.Now()).
 			Save(ctx)
 	}

--- a/pkg/infrastructure/mysql/user/user_level_repository.go
+++ b/pkg/infrastructure/mysql/user/user_level_repository.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"time"
 
+	"github.com/arpb2/C-3PO/third_party/ent/level"
+
 	user3 "github.com/arpb2/C-3PO/pkg/data/repository/user"
 	user2 "github.com/arpb2/C-3PO/pkg/domain/model/user"
 
 	"github.com/arpb2/C-3PO/pkg/domain/http"
 	"github.com/arpb2/C-3PO/third_party/ent"
-	"github.com/arpb2/C-3PO/third_party/ent/level"
 	"github.com/arpb2/C-3PO/third_party/ent/user"
 	"github.com/arpb2/C-3PO/third_party/ent/userlevel"
 )

--- a/pkg/presentation/level/testdata/ok.get_level.golden.json
+++ b/pkg/presentation/level/testdata/ok.get_level.golden.json
@@ -1,1 +1,1 @@
-{"id":1000,"name":"Some name","description":"Some description"}
+{"id":1000,"name":"Some name","description":"Some description","definition":{"origin":{"position":{"x":0,"y":0},"orientation":""},"destination":{"position":{"x":0,"y":0},"active":false,"conditions":null},"minimal_dimension":{"rows":0,"columns":0},"collectibles":null,"gates":null,"pads":null}}

--- a/pkg/presentation/level/testdata/ok.put_level.golden.json
+++ b/pkg/presentation/level/testdata/ok.put_level.golden.json
@@ -1,1 +1,1 @@
-{"id":1000,"name":"Some name","description":"Some description"}
+{"id":1000,"name":"Some name","description":"Some description","definition":{"origin":{"position":{"x":0,"y":0},"orientation":""},"destination":{"position":{"x":0,"y":0},"active":false,"conditions":null},"minimal_dimension":{"rows":0,"columns":0},"collectibles":null,"gates":null,"pads":null}}

--- a/third_party/ent/level/level.go
+++ b/third_party/ent/level/level.go
@@ -10,11 +10,12 @@ const (
 	// Label holds the string label denoting the level type in the database.
 	Label = "level"
 	// FieldID holds the string denoting the id field in the database.
-	FieldID          = "id"         // FieldCreatedAt holds the string denoting the created_at vertex property in the database.
-	FieldCreatedAt   = "created_at" // FieldUpdatedAt holds the string denoting the updated_at vertex property in the database.
-	FieldUpdatedAt   = "updated_at" // FieldName holds the string denoting the name vertex property in the database.
-	FieldName        = "name"       // FieldDescription holds the string denoting the description vertex property in the database.
-	FieldDescription = "description"
+	FieldID          = "id"          // FieldCreatedAt holds the string denoting the created_at vertex property in the database.
+	FieldCreatedAt   = "created_at"  // FieldUpdatedAt holds the string denoting the updated_at vertex property in the database.
+	FieldUpdatedAt   = "updated_at"  // FieldName holds the string denoting the name vertex property in the database.
+	FieldName        = "name"        // FieldDescription holds the string denoting the description vertex property in the database.
+	FieldDescription = "description" // FieldDefinition holds the string denoting the definition vertex property in the database.
+	FieldDefinition  = "definition"
 
 	// Table holds the table name of the level in the database.
 	Table = "levels"
@@ -27,6 +28,7 @@ var Columns = []string{
 	FieldUpdatedAt,
 	FieldName,
 	FieldDescription,
+	FieldDefinition,
 }
 
 var (

--- a/third_party/ent/level_create.go
+++ b/third_party/ent/level_create.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/arpb2/C-3PO/third_party/ent/level"
+	"github.com/arpb2/C-3PO/third_party/ent/schema"
 	"github.com/facebookincubator/ent/dialect/sql/sqlgraph"
 	"github.com/facebookincubator/ent/schema/field"
 )
@@ -60,6 +61,12 @@ func (lc *LevelCreate) SetDescription(s string) *LevelCreate {
 	return lc
 }
 
+// SetDefinition sets the definition field.
+func (lc *LevelCreate) SetDefinition(sd *schema.LevelDefinition) *LevelCreate {
+	lc.mutation.SetDefinition(sd)
+	return lc
+}
+
 // SetID sets the id field.
 func (lc *LevelCreate) SetID(u uint) *LevelCreate {
 	lc.mutation.SetID(u)
@@ -91,6 +98,9 @@ func (lc *LevelCreate) Save(ctx context.Context) (*Level, error) {
 		if err := level.DescriptionValidator(v); err != nil {
 			return nil, fmt.Errorf("ent: validator failed for field \"description\": %v", err)
 		}
+	}
+	if _, ok := lc.mutation.Definition(); !ok {
+		return nil, errors.New("ent: missing required field \"definition\"")
 	}
 	var (
 		err  error
@@ -173,6 +183,14 @@ func (lc *LevelCreate) sqlSave(ctx context.Context) (*Level, error) {
 			Column: level.FieldDescription,
 		})
 		l.Description = value
+	}
+	if value, ok := lc.mutation.Definition(); ok {
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
+			Type:   field.TypeJSON,
+			Value:  value,
+			Column: level.FieldDefinition,
+		})
+		l.Definition = value
 	}
 	if err := sqlgraph.CreateNode(ctx, lc.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {

--- a/third_party/ent/level_update.go
+++ b/third_party/ent/level_update.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/arpb2/C-3PO/third_party/ent/level"
 	"github.com/arpb2/C-3PO/third_party/ent/predicate"
+	"github.com/arpb2/C-3PO/third_party/ent/schema"
 	"github.com/facebookincubator/ent/dialect/sql"
 	"github.com/facebookincubator/ent/dialect/sql/sqlgraph"
 	"github.com/facebookincubator/ent/schema/field"
@@ -43,6 +44,12 @@ func (lu *LevelUpdate) SetName(s string) *LevelUpdate {
 // SetDescription sets the description field.
 func (lu *LevelUpdate) SetDescription(s string) *LevelUpdate {
 	lu.mutation.SetDescription(s)
+	return lu
+}
+
+// SetDefinition sets the definition field.
+func (lu *LevelUpdate) SetDefinition(sd *schema.LevelDefinition) *LevelUpdate {
+	lu.mutation.SetDefinition(sd)
 	return lu
 }
 
@@ -149,6 +156,13 @@ func (lu *LevelUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Column: level.FieldDescription,
 		})
 	}
+	if value, ok := lu.mutation.Definition(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeJSON,
+			Value:  value,
+			Column: level.FieldDefinition,
+		})
+	}
 	if n, err = sqlgraph.UpdateNodes(ctx, lu.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{level.Label}
@@ -182,6 +196,12 @@ func (luo *LevelUpdateOne) SetName(s string) *LevelUpdateOne {
 // SetDescription sets the description field.
 func (luo *LevelUpdateOne) SetDescription(s string) *LevelUpdateOne {
 	luo.mutation.SetDescription(s)
+	return luo
+}
+
+// SetDefinition sets the definition field.
+func (luo *LevelUpdateOne) SetDefinition(sd *schema.LevelDefinition) *LevelUpdateOne {
+	luo.mutation.SetDefinition(sd)
 	return luo
 }
 
@@ -284,6 +304,13 @@ func (luo *LevelUpdateOne) sqlSave(ctx context.Context) (l *Level, err error) {
 			Type:   field.TypeString,
 			Value:  value,
 			Column: level.FieldDescription,
+		})
+	}
+	if value, ok := luo.mutation.Definition(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeJSON,
+			Value:  value,
+			Column: level.FieldDefinition,
 		})
 	}
 	l = &Level{config: luo.config}

--- a/third_party/ent/migrate/schema.go
+++ b/third_party/ent/migrate/schema.go
@@ -44,6 +44,7 @@ var (
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "name", Type: field.TypeString},
 		{Name: "description", Type: field.TypeString},
+		{Name: "definition", Type: field.TypeJSON},
 	}
 	// LevelsTable holds the schema information for the "levels" table.
 	LevelsTable = &schema.Table{

--- a/third_party/ent/mutation.go
+++ b/third_party/ent/mutation.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/arpb2/C-3PO/third_party/ent/credential"
 	"github.com/arpb2/C-3PO/third_party/ent/level"
+	"github.com/arpb2/C-3PO/third_party/ent/schema"
 	"github.com/arpb2/C-3PO/third_party/ent/user"
 	"github.com/arpb2/C-3PO/third_party/ent/userlevel"
 
@@ -367,6 +368,7 @@ type LevelMutation struct {
 	updated_at    *time.Time
 	name          *string
 	description   *string
+	definition    **schema.LevelDefinition
 	clearedFields map[string]struct{}
 }
 
@@ -492,6 +494,25 @@ func (m *LevelMutation) ResetDescription() {
 	m.description = nil
 }
 
+// SetDefinition sets the definition field.
+func (m *LevelMutation) SetDefinition(sd *schema.LevelDefinition) {
+	m.definition = &sd
+}
+
+// Definition returns the definition value in the mutation.
+func (m *LevelMutation) Definition() (r *schema.LevelDefinition, exists bool) {
+	v := m.definition
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetDefinition reset all changes of the definition field.
+func (m *LevelMutation) ResetDefinition() {
+	m.definition = nil
+}
+
 // Op returns the operation name.
 func (m *LevelMutation) Op() Op {
 	return m.op
@@ -506,7 +527,7 @@ func (m *LevelMutation) Type() string {
 // this mutation. Note that, in order to get all numeric
 // fields that were in/decremented, call AddedFields().
 func (m *LevelMutation) Fields() []string {
-	fields := make([]string, 0, 4)
+	fields := make([]string, 0, 5)
 	if m.created_at != nil {
 		fields = append(fields, level.FieldCreatedAt)
 	}
@@ -518,6 +539,9 @@ func (m *LevelMutation) Fields() []string {
 	}
 	if m.description != nil {
 		fields = append(fields, level.FieldDescription)
+	}
+	if m.definition != nil {
+		fields = append(fields, level.FieldDefinition)
 	}
 	return fields
 }
@@ -535,6 +559,8 @@ func (m *LevelMutation) Field(name string) (ent.Value, bool) {
 		return m.Name()
 	case level.FieldDescription:
 		return m.Description()
+	case level.FieldDefinition:
+		return m.Definition()
 	}
 	return nil, false
 }
@@ -571,6 +597,13 @@ func (m *LevelMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetDescription(v)
+		return nil
+	case level.FieldDefinition:
+		v, ok := value.(*schema.LevelDefinition)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDefinition(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Level field %s", name)
@@ -633,6 +666,9 @@ func (m *LevelMutation) ResetField(name string) error {
 		return nil
 	case level.FieldDescription:
 		m.ResetDescription()
+		return nil
+	case level.FieldDefinition:
+		m.ResetDefinition()
 		return nil
 	}
 	return fmt.Errorf("unknown Level field %s", name)

--- a/third_party/ent/schema/level.go
+++ b/third_party/ent/schema/level.go
@@ -3,9 +3,13 @@ package schema
 import (
 	"time"
 
+	"github.com/arpb2/C-3PO/pkg/domain/model/level"
+
 	"github.com/facebookincubator/ent"
 	"github.com/facebookincubator/ent/schema/field"
 )
+
+type LevelDefinition level.Definition
 
 // Level holds the schema definition for the Level entity.
 type Level struct {
@@ -19,6 +23,7 @@ func (Level) Fields() []ent.Field {
 		field.Time("updated_at").Default(time.Now).UpdateDefault(time.Now),
 		field.String("name").NotEmpty(),
 		field.String("description").NotEmpty(),
+		field.JSON("definition", &LevelDefinition{}),
 	}
 }
 


### PR DESCRIPTION
- Add domain structures for a level definition
- Update schema to reflect level definition as a json
- Bind level definition at use-cases (transparent, nothing to do)
- Update tests to reflect definition on responses